### PR TITLE
Icetv bw atv merge

### DIFF
--- a/lib/python/Components/Converter/genre.py
+++ b/lib/python/Components/Converter/genre.py
@@ -389,6 +389,152 @@ class GenresAUSIceTV:
 		),
 	}
 
+class GenresDEUIceTV:
+	maintype = (
+		_("Miscellaneous"),
+		_("Movie/Drama"),
+		_("News/Current Affairs"),
+		_("Show/Games show"),
+		_("Sports"),
+		_("Children/Youth"),
+		_("Music/Ballet/Dance"),
+		_("Arts/Culture"),
+		_("Social/Political/Economics"),
+		_("Education/Science/Factual"),
+		_("Leisure hobbies"),
+		_("Special"),
+		_("Comedy"),
+		_("Drama"),
+		_("Documentary"),
+		_("Real Life"),
+	)
+
+	subtype = {
+		# Miscellaneous
+		0: (
+			_(''),  # 0x00
+			_('Abenteuer'),  # 0x01
+			_('Zeichentrick'),  # 0x02 remapped from 0x01
+			_('Wissen'),  # 0x03 remapped from 0x01
+			_('Wirtschat'),  # 0x04 remapped from 0x01
+			_('Wintersport'),  # 0x05 remapped from 0x01
+			_('Wetter'),  # 0x06 remapped from 0x01
+			_('Western'),  # 0x07 remapped from 0x01
+			_('Werbung'),  # 0x08 remapped from 0x01
+			_('Wassersport'),  # 0x09 remapped from 0x01
+			_('Vorschau'),  # 0x0a remapped from 0x01
+			_('Volleyball'),  # 0x0b remapped from 0x01
+			_('Volksmusik'),  # 0x0c remapped from 0x01
+			_('Videoclip'),  # 0x0d remapped from 0x01
+			_('Verschiedenes'),  # 0x0e remapped from 0x01
+			_('US-Sport'),  # 0x0f remapped from 0x01
+		),
+		# Movie/Drama
+		1: (
+			_('Erotik'),  # 0x10 remapped from 0x01
+			_('Eishockey'),  # 0x11 remapped from 0x01
+			_('Drama'),  # 0x12 remapped from 0x01
+			_('Dokumentation'),  # 0x13 remapped from 0x01
+			_('Comedy'),  # 0x14
+			_('Dokumentarfilm'),  # 0x15 remapped from 0x01
+			_('Clips'),  # 0x16 remapped from 0x01
+			_('Boxen'),  # 0x17 remapped from 0x01
+			_('Bericht'),  # 0x18 remapped from 0x01
+			_('Anime'),  # 0x19 remapped from 0x01
+			_('Alternative'),  # 0x1a remapped from 0x01
+			_('Action'),  # 0x1b remapped from 0x01
+		),
+		# Sports
+		4: (
+			_('Sport'),  # 0x40
+		),
+		# Social/Political/Economics
+		8: (
+			_('Unused 0x80'),  # 0x80
+			_('Current Affairs'),  # 0x81
+		),
+		# Special
+		11: (
+			_('Special'),  # 0xb0
+		),
+		# Comedy
+		12: (
+			_('Comedy'),  # 0xc0
+			_('Reise'),  # 0xc1 remapped from 0x01
+			_('Reality'),  # 0xc2 remapped from 0x01
+			_('Ratgeber'),  # 0xc3 remapped from 0x01
+			_('Radsport'),  # 0xc4 remapped from 0x01
+			_('Pop'),  # 0xc5 remapped from 0x01
+			_('Politik'),  # 0xc6 remapped from 0x01
+			_('Olympia'),  # 0xc7 remapped from 0x01
+			_('Natur'),  # 0xc8 remapped from 0x01
+			_('Nachrichten'),  # 0xc9 remapped from 0x01
+			_('Mystery + Horror'),  # 0xca remapped from 0x01
+			_('Musik'),  # 0xcb remapped from 0x01
+			_('Musical'),  # 0xcc remapped from 0x01
+			_('Motorsport'),  # 0xcd remapped from 0x01
+			_('Motor + Verkehr'),  # 0xce remapped from 0x01
+			_('Magazin'),  # 0xcf remapped from 0x01
+		),
+		# Drama
+		13: (
+			_('Drama'),  # 0xd0
+			_('Leichtathletik'),  # 0xd1 remapped from 0x01
+			_('Kurzfilm'),  # 0xd2 remapped from 0x01
+			_('Kultur'),  # 0xd3 remapped from 0x01
+			_('Krimi'),  # 0xd4 remapped from 0x01
+			_('Krankenhaus'),  # 0xd5 remapped from 0x01
+			_('Kochshow'),  # 0xd6 remapped from 0x01
+			_('Klassik'),  # 0xd7 remapped from 0x01
+			_('Kino'),  # 0xd8 remapped from 0x01
+			_('Kinder'),  # 0xd9 remapped from 0x01
+			_('Jugend'),  # 0xda remapped from 0x01
+			_('Jazz'),  # 0xdb remapped from 0x01
+			_('Interview'),  # 0xdc remapped from 0x01
+			_('Information'),  # 0xdd remapped from 0x01
+			_('Humor'),  # 0xde remapped from 0x01
+			_('Homeshopping'),  # 0xdf remapped from 0x01
+		),
+		# Documentary
+		14: (
+			_('Documentary'),  # 0xe0
+			_('Heimwerken'),  # 0xe1 remapped from 0x01
+			_('Heimat'),  # 0xe2 remapped from 0x01
+			_('Handball'),  # 0xe3 remapped from 0x01
+			_('Gymnastik'),  # 0xe4 remapped from 0x01
+			_('Golf'),  # 0xe5 remapped from 0x01
+			_('Gesundheit'),  # 0xe6 remapped from 0x01
+			_('Geschichte'),  # 0xe7 remapped from 0x01
+			_('Gerichtsshow'),  # 0xe8 remapped from 0x01
+			_('Fu\xc3\x9fball'),  # 0xe9 remapped from 0x01
+			_('Filme'),  # 0xea remapped from 0x01
+			_('Fantasy'),  # 0xeb remapped from 0x01
+			_('Familien-Show'),  # 0xec remapped from 0x01
+			_('Familie'),  # 0xed remapped from 0x01
+			_('Extremsport'),  # 0xee remapped from 0x01
+			_('Event'),  # 0xef remapped from 0x01
+		),
+		# Real Life
+		15: (
+			_('Thriller'),  # 0xf0 remapped from 0x01
+			_('Theater'),  # 0xf1 remapped from 0x01
+			_('Tennis'),  # 0xf2 remapped from 0x01
+			_('Talkshows'),  # 0xf3 remapped from 0x01
+			_('Spielshows'),  # 0xf4 remapped from 0x01
+			_('Spielfilm'),  # 0xf5 remapped from 0x01
+			_('Soap'),  # 0xf6 remapped from 0x01
+			_('Shows'),  # 0xf7 remapped from 0x01
+			_('Show'),  # 0xf8 remapped from 0x01
+			_('Serien'),  # 0xf9 remapped from 0x01
+			_('Serie'),  # 0xfa remapped from 0x01
+			_('Science Fiction'),  # 0xfb remapped from 0x01
+			_('Romantik/Liebe'),  # 0xfc remapped from 0x01
+			_('Rock'),  # 0xfd remapped from 0x01
+			_('Reportagen'),  # 0xfe remapped from 0x01
+			_('Reportage'),  # 0xff remapped from 0x01
+		),
+	}
+
 def __getGenreStringMain(hn, ln, genres):
 	# if hn == 0:
 	# 	return _("Undefined content")
@@ -429,8 +575,9 @@ def __getGenreStringSubIceTV(hn, ln, genres):
 
 countries = {
 	"AUS": (__getGenreStringMain, __getGenreStringMain, GenresAUS()),
-	# Use illegal country name for IceTV so that it won't match a real country
+	# Use illegal country names for IceTV genre tables so that they won't match real countries
 	"AUSIceTV": (__getGenreStringMainIceTV, __getGenreStringSubIceTV, GenresAUSIceTV()),
+	"DEUIceTV": (__getGenreStringMainIceTV, __getGenreStringSubIceTV, GenresDEUIceTV()),
 }
 
 defaultGenre = GenresETSI()
@@ -442,10 +589,13 @@ maintype = defaultGenre.maintype
 subtype = defaultGenre.subtype
 
 def __remapCountry(country):
-	if country == "AUS" and hasattr(config.plugins, "icetv") and config.plugins.icetv.enable_epg.value:
-		return "AUSIceTV"
-	else:
-		return country
+	if hasattr(config.plugins, "icetv") and config.plugins.icetv.enable_epg.value:
+		if not country:
+			country = config.plugins.icetv.member.country.value
+		iceTVCountry = country + "IceTV"
+		if iceTVCountry in countries:
+			return iceTVCountry
+	return country
 
 def getGenreStringMain(hn, ln, country=None):
 	countryInfo = countries.get(__remapCountry(country), defaultCountryInfo)
@@ -461,7 +611,7 @@ def getGenreStringLong(hn, ln, country=None):
 	if hn == 15 and not (hasattr(config.plugins, "icetv") and config.plugins.icetv.enable_epg.value):
 		return _("User defined") + " " + str(ln)
 	main = getGenreStringMain(hn, ln, country=country)
-	sub = getGenreStringSub(hn, ln)
+	sub = getGenreStringSub(hn, ln, country=country)
 	if main and main != sub:
 		return main + ": " + sub
 	else:

--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -16,19 +16,21 @@ from socket import socket, create_connection, AF_INET, SOCK_DGRAM, SHUT_RDWR, er
 from . import config, saveConfigFile, getIceTVDeviceType
 from boxbranding import getMachineBrand, getMachineName, getImageBuild
 
-_version_string = "20190921"
+_version_string = "20190930"
 _protocol = "http://"
-if getMachineBrand() == "BEYONWIZ":
-    _server = "api.icetv.com.au"
-else:
-    _server = "api.icetv.de"
 _device_type_id = getIceTVDeviceType()
 _debug_level = 0  # 1 = request/reply, 2 = 1+headers, 3 = 2+partial body, 4 = 2+full body
 
+print "[IceTV] server set to", config.plugins.icetv.server.name.value
+
+iceTVServers = {
+    _("Australia"): "api.icetv.com.au",
+    _("Germany"): "api.icetv.de",
+}
 
 def isServerReachable():
     try:
-        sock = create_connection((_server, 80), 3)
+        sock = create_connection((config.plugins.icetv.server.name.value, 80), 3)
         sock.shutdown(SHUT_RDWR)
         sock.close()
         return True
@@ -79,7 +81,7 @@ class Request(object):
             "Accept": "application/json",
             "User-Agent": "SystemPlugins.IceTV/%s (%s; %s; %s)" % (_version_string, getMachineBrand(), getMachineName(), getImageBuild()),
         }
-        self.url = _protocol + _server + resource
+        self.url = _protocol + config.plugins.icetv.server.name.value + resource
         self.data = {}
         self.response = None
 

--- a/lib/python/Plugins/SystemPlugins/IceTV/API.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/API.py
@@ -290,3 +290,11 @@ class Timer(AuthRequest):
 
     def delete(self):
         return self.send("delete")
+
+
+class Scans(AuthRequest):
+    def __init__(self):
+        super(Scans, self).__init__("/scans")
+
+    def post(self):
+        return self.send("post")

--- a/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/__init__.py
@@ -21,22 +21,17 @@ def getIceTVDeviceType():
         ("Beyonwiz", "V2"): 38,
     }.get((getMachineBrand(), getMachineName()), 22)
 
-def getCountryCode(cc):
-    code = "INT"
-    from Tools.CountryCodes import ISO3166
-    for country in ISO3166:
-        if _(cc).upper() == country[0].upper():
-            code = country[2]
-            break
-    return code
-
 config.plugins.icetv = ConfigSubsection()
+
+config.plugins.icetv.server = ConfigSubsection()
+config.plugins.icetv.server.name = ConfigText(default="api.icetv.com.au")
+
 config.plugins.icetv.member = ConfigSubsection()
 config.plugins.icetv.member.email_address = ConfigText(show_help=False, fixed_size=False)
 config.plugins.icetv.member.token = ConfigText()
 config.plugins.icetv.member.id = ConfigNumber()
 config.plugins.icetv.member.region_id = ConfigNumber()
-config.plugins.icetv.member.country = ConfigText()
+config.plugins.icetv.member.country = ConfigText(default="AUS")
 
 config.plugins.icetv.member.password = NoSave(ConfigPassword(censor="●", show_help=False, fixed_size=False))
 

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -329,13 +329,13 @@ class EPGFetcher(object):
 
     def doWork(self):
         global password_requested
-        self.addLog("Start update")
+        self.addLog(_("Start update"))
         if password_requested:
             self.addLog(_("Can not proceed - you need to login first"))
             return False
         if not ice.haveCredentials():
             password_requested = True
-            self.addLog("No token, requesting password...")
+            self.addLog(_("No token, requesting password..."))
             _session.open(IceTVNeedPassword)
             if not ice.haveCredentials():
                 return False
@@ -383,7 +383,7 @@ class EPGFetcher(object):
             password_requested = True
             self.addLog(_("No token, requesting password..."))
             _session.open(IceTVNeedPassword)
-        self.addLog("End update")
+        self.addLog(_("End update"))
         self.deferredPostStatus(None)
         self.statusCleanup()
         return res
@@ -555,7 +555,7 @@ class EPGFetcher(object):
                                     iceTimer["state"] = "failed"
                                     iceTimer["message"] = "Timer conflict: '%s'" % "', '".join(names)
                                     # print "[IceTV] Timer conflict:", conflicts
-                                    self.addLog("Timer '%s' conflicts with %s" % (name, "', '".join([n for n in names if n != name])))
+                                    self.addLog(_("Timer '%s' conflicts with %s") % (name, "', '".join([n for n in names if n != name])))
                     if not completed and not updated and not created:
                         iceTimer["state"] = "failed"
                         update_queue.append(iceTimer)
@@ -569,7 +569,7 @@ class EPGFetcher(object):
         res = True
         try:
             self.putTimers(update_queue)
-            self.addLog("Timers updated OK")
+            self.addLog(_("Timers updated OK"))
         except KeyError as ex:
             print "[IceTV] ", str(ex)
             res = False
@@ -689,7 +689,7 @@ class EPGFetcher(object):
                 timer["message"] = "Will record on %s" % config.plugins.icetv.device.label.value
             req.data["timers"] = [timer]
             res = req.put().json()
-            self.addLog("Timer '%s' updated OK" % local_timer.name)
+            self.addLog(_("Timer '%s' updated OK") % local_timer.name)
         except (IOError, RuntimeError, KeyError) as ex:
             _logResponseException(self, _("Can not update timer"), ex)
 
@@ -723,7 +723,7 @@ class EPGFetcher(object):
                 res = req.post()
                 try:
                     local_timer.ice_timer_id = res.json()["timers"][0]["id"].encode("utf-8")
-                    self.addLog("Timer '%s' created OK" % local_timer.name)
+                    self.addLog(_("Timer '%s' created OK") % local_timer.name)
                     if local_timer.ice_timer_id is not None:
                         NavigationInstance.instance.RecordTimer.saveTimer()
                         self.deferredPostStatus(local_timer)
@@ -1233,7 +1233,7 @@ class IceTVNeedPassword(ConfigListScreen, Screen):
             self.close()
             global password_requested
             password_requested = False
-            fetcher.addLog("Login OK")
+            fetcher.addLog(_("Login OK"))
             fetcher.createFetchJob()
         except (IOError, RuntimeError) as ex:
             msg = _logResponseException(fetcher, _("Login failure"), ex)

--- a/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
+++ b/lib/python/Plugins/SystemPlugins/IceTV/plugin.py
@@ -200,21 +200,21 @@ class EPGFetcher(object):
             return False
 
     def onTimerAdded(self, entry):
-        #print "[IceTV] timer added: ", entry
+        # print "[IceTV] timer added: ", entry
         if not self.shouldProcessTimer(entry):
             return
-        #print "[IceTV] Add timer job"
+        # print "[IceTV] Add timer job"
         reactor.callInThread(self.postTimer, entry)
 
     def onTimerRemoved(self, entry):
-        #print "[IceTV] timer removed: ", entry
+        # print "[IceTV] timer removed: ", entry
         if not self.shouldProcessTimer(entry) or not entry.ice_timer_id:
             return
-        #print "[IceTV] Delete timer job"
+        # print "[IceTV] Delete timer job"
         reactor.callInThread(self.deleteTimer, entry.ice_timer_id)
 
     def onTimerChanged(self, entry):
-        #print "[IceTV] timer changed: ", entry
+        # print "[IceTV] timer changed: ", entry
 
         # If entry.cancelled is True, the timer is being deleted
         # and will be processed by a subsequent onTimerRemoved() call
@@ -226,14 +226,14 @@ class EPGFetcher(object):
             return
         if entry.ice_timer_id is None:
             # New timer as far as IceTV is concerned
-            #print "[IceTV] Add timer job"
+            # print "[IceTV] Add timer job"
             reactor.callInThread(self.postTimer, entry)
         else:
-            #print "[IceTV] Modify timer jobs"
+            # print "[IceTV] Modify timer jobs"
             ice_timer_id = entry.ice_timer_id
             entry.ice_timer_id = None
             # Delete the timer on the IceTV side, then post the new one
-            #print "[IceTV] Modify timer jobs - delete timer job"
+            # print "[IceTV] Modify timer jobs - delete timer job"
             d = threads.deferToThread(lambda: self.deleteTimer(ice_timer_id))
             d.addCallback(lambda x: self.deferredPostTimer(entry))
 
@@ -299,7 +299,7 @@ class EPGFetcher(object):
         doTimeouts(self.failed, old24h)
 
     def deferredPostTimer(self, entry):
-        #print "[IceTV] Modify timer jobs - add timer job"
+        # print "[IceTV] Modify timer jobs - add timer job"
         reactor.callInThread(self.postTimer, entry)
 
     def deferredPostStatus(self, entry):
@@ -316,7 +316,7 @@ class EPGFetcher(object):
     def addLog(self, msg):
         logMsg = "%s: %s" % (str(datetime.now()).split(".")[0], msg)
         self.log.append(logMsg)
-        #print "[IceTV]", logMsg
+        print "[IceTV]", logMsg
 
     def createFetchJob(self, res=None):
         if config.plugins.icetv.configured.value and config.plugins.icetv.enable_epg.value:
@@ -324,7 +324,7 @@ class EPGFetcher(object):
             if password_requested:
                 self.addLog(_("Can not proceed - you need to login first"))
                 return
-            #print "[IceTV] Create fetch job"
+            # print "[IceTV] Create fetch job"
             reactor.callInThread(self.doWork)
 
     def doWork(self):
@@ -427,9 +427,9 @@ class EPGFetcher(object):
                 start = int(timegm(strptime(show["start"].split("+")[0], "%Y-%m-%dT%H:%M:%S")))
                 stop = int(timegm(strptime(show["stop"].split("+")[0], "%Y-%m-%dT%H:%M:%S")))
                 duration = stop - start
-            title = show.get("title", "").encode('utf-8')
-            short = show.get("subtitle", "").encode('utf-8')
-            extended = show.get("desc", "").encode('utf-8')
+            title = show.get("title", "").encode("utf-8")
+            short = show.get("subtitle", "").encode("utf-8")
+            extended = show.get("desc", "").encode("utf-8")
             genres = []
             for g in show.get("category", []):
                 name = g['name']
@@ -440,8 +440,8 @@ class EPGFetcher(object):
                         genres.append(eit_remap)
                 else:
                     pass
-                    #print '[EPGFetcher] ERROR: lookup of 0x%02x%s "%s" returned \"%s"' % (eit, (" (remapped to 0x%02x)" % eit_remap) if eit != eit_remap else "", name, mapped_name)
-            p_rating = ((config.plugins.icetv.member.country.value, parental_ratings.get(show.get("rating", "").encode('utf-8'), 0x00)),)
+                    # print '[EPGFetcher] ERROR: lookup of 0x%02x%s "%s" returned \"%s"' % (eit, (" (remapped to 0x%02x)" % eit_remap) if eit != eit_remap else "", name, mapped_name)
+            p_rating = ((config.plugins.icetv.member.country.value, parental_ratings.get(show.get("rating", "").encode("utf-8"), 0x00)),)
             res[channel_id].append((start, duration, title, short, extended, genres, event_id, p_rating))
         return res
 
@@ -459,17 +459,17 @@ class EPGFetcher(object):
                 evt = timer.getEventFromEPGId() or timer.getEventFromEPG()
                 if evt:
                     timer_updated = False
-                    servicename = timer.service_ref.getServiceName()
+                    # servicename = timer.service_ref.getServiceName()
                     desc = attrNewlines(evt.getShortDescription())
                     if not desc:
                         desc = attrNewlines(evt.getExtendedDescription())
                     if desc and timer.description != desc and attrNewlines(timer.description) != desc:
-                            #print "[EPGFetcher] updateDescriptions from EPG description", servicename, "'" + timer.name + "':", "'" + timer.description + "' -> '" + desc + "'"
+                            # print "[EPGFetcher] updateDescriptions from EPG description", servicename, "'" + timer.name + "':", "'" + timer.description + "' -> '" + desc + "'"
                             timer.description = desc
                             timer_updated = True
                     eit = evt.getEventId()
                     if eit and timer.eit != eit:
-                            #print "[EPGFetcher] updateDescriptions from EPG eit", servicename, "'" + timer.name + "':", timer.eit, "->", eit
+                            # print "[EPGFetcher] updateDescriptions from EPG eit", servicename, "'" + timer.name + "':", timer.eit, "->", eit
                             timer.eit = eit
                             timer_updated = True
                     if timer_updated:
@@ -480,19 +480,19 @@ class EPGFetcher(object):
     def processTimers(self, timers):
         update_queue = []
         for iceTimer in timers:
-            #print "[IceTV] iceTimer:", iceTimer
+            # print "[IceTV] iceTimer:", iceTimer
             try:
-                action = iceTimer.get("action", "").encode('utf-8')
-                state = iceTimer.get("state", "").encode('utf-8')
-                name = iceTimer.get("name", "").encode('utf-8')
+                action = iceTimer.get("action", "").encode("utf-8")
+                state = iceTimer.get("state", "").encode("utf-8")
+                name = iceTimer.get("name", "").encode("utf-8")
                 start = int(timegm(strptime(iceTimer["start_time"].split("+")[0], "%Y-%m-%dT%H:%M:%S")))
                 duration = 60 * int(iceTimer["duration_minutes"])
                 channel_id = long(iceTimer["channel_id"])
-                ice_timer_id = iceTimer["id"].encode('utf-8')
+                ice_timer_id = iceTimer["id"].encode("utf-8")
                 if action == "forget":
                     for timer in _session.nav.RecordTimer.timer_list:
                         if timer.ice_timer_id == ice_timer_id:
-                            #print "[IceTV] removing timer:", timer
+                            # print "[IceTV] removing timer:", timer
                             _session.nav.RecordTimer.removeEntry(timer)
                             break
                     else:
@@ -503,7 +503,7 @@ class EPGFetcher(object):
                     completed = False
                     for timer in _session.nav.RecordTimer.processed_timers:
                         if timer.ice_timer_id == ice_timer_id:
-                            #print "[IceTV] completed timer:", timer
+                            # print "[IceTV] completed timer:", timer
                             iceTimer["state"] = "completed"
                             iceTimer["message"] = "Done"
                             update_queue.append(iceTimer)
@@ -512,7 +512,7 @@ class EPGFetcher(object):
                     if not completed:
                         for timer in _session.nav.RecordTimer.timer_list:
                             if timer.ice_timer_id == ice_timer_id:
-                                #print "[IceTV] updating timer:", timer
+                                # print "[IceTV] updating timer:", timer
                                 eit = int(iceTimer.get("eit_id", -1))
                                 if eit <= 0:
                                     eit = None
@@ -530,7 +530,7 @@ class EPGFetcher(object):
                     created = False
                     if not completed and not updated:
                         channels = self.channel_service_map[channel_id]
-                        #print "[IceTV] channel_id %s maps to" % channel_id, channels
+                        # print "[IceTV] channel_id %s maps to" % channel_id, channels
                         db = eDVBDB.getInstance()
                         # Sentinel values used if there are no channel matches
                         iceTimer["state"] = "failed"
@@ -539,7 +539,7 @@ class EPGFetcher(object):
                             serviceref = db.searchReference(channel[1], channel[0], channel[2])
                             if serviceref.valid():
                                 serviceref = ServiceReference(eServiceReference(serviceref))
-                                #print "[IceTV] New %s is valid" % str(serviceref), serviceref.getServiceName()
+                                # print "[IceTV] New %s is valid" % str(serviceref), serviceref.getServiceName()
                                 eit = int(iceTimer.get("eit_id", -1))
                                 if eit <= 0:
                                     eit = None
@@ -554,7 +554,7 @@ class EPGFetcher(object):
                                     names = [r.name for r in conflicts]
                                     iceTimer["state"] = "failed"
                                     iceTimer["message"] = "Timer conflict: '%s'" % "', '".join(names)
-                                    #print "[IceTV] Timer conflict:", conflicts
+                                    # print "[IceTV] Timer conflict:", conflicts
                                     self.addLog("Timer '%s' conflicts with %s" % (name, "', '".join([n for n in names if n != name])))
                     if not completed and not updated and not created:
                         iceTimer["state"] = "failed"
@@ -579,14 +579,14 @@ class EPGFetcher(object):
         return res
 
     def isIceTimerInUpdateQueue(self, iceTimer, update_queue):
-        ice_timer_id = iceTimer["id"].encode('utf-8')
+        ice_timer_id = iceTimer["id"].encode("utf-8")
         for timer in update_queue:
-            if ice_timer_id == timer["id"].encode('utf-8'):
+            if ice_timer_id == timer["id"].encode("utf-8"):
                 return True
         return False
 
     def isIceTimerInLocalTimerList(self, iceTimer, ignoreCompleted=False):
-        ice_timer_id = iceTimer["id"].encode('utf-8')
+        ice_timer_id = iceTimer["id"].encode("utf-8")
         for timer in _session.nav.RecordTimer.timer_list:
             if timer.ice_timer_id == ice_timer_id:
                 return True
@@ -603,7 +603,7 @@ class EPGFetcher(object):
             serviceref = db.searchReference(channel[1], channel[0], channel[2])
             if serviceref.valid():
                 serviceref = ServiceReference(eServiceReference(serviceref))
-                #print "[IceTV] Updated %s is valid" % str(serviceref), serviceref.getServiceName()
+                # print "[IceTV] Updated %s is valid" % str(serviceref), serviceref.getServiceName()
                 if str(timer.service_ref) != str(serviceref):
                     changed = True
                     timer.service_ref = serviceref
@@ -665,7 +665,7 @@ class EPGFetcher(object):
 
     def putTimer(self, local_timer):
         try:
-            #print "[IceTV] updating ice_timer", local_timer.ice_timer_id
+            # print "[IceTV] updating ice_timer", local_timer.ice_timer_id
             req = ice.Timer(local_timer.ice_timer_id)
             timer = {}
             if not local_timer.eit:
@@ -702,7 +702,7 @@ class EPGFetcher(object):
                 return
         if local_timer.ice_timer_id is None:
             try:
-                #print "[IceTV] uploading new timer"
+                # print "[IceTV] uploading new timer"
                 if not local_timer.eit:
                     self.addLog(_("Timer '%s' has no event id; not sent to IceTV") % local_timer.name)
                     return
@@ -722,7 +722,7 @@ class EPGFetcher(object):
                 req.data["duration_minutes"] = ((local_timer.end - config.recording.margin_after.value * 60) - (local_timer.begin + config.recording.margin_before.value * 60)) / 60
                 res = req.post()
                 try:
-                    local_timer.ice_timer_id = res.json()["timers"][0]["id"].encode('utf-8')
+                    local_timer.ice_timer_id = res.json()["timers"][0]["id"].encode("utf-8")
                     self.addLog("Timer '%s' created OK" % local_timer.name)
                     if local_timer.ice_timer_id is not None:
                         NavigationInstance.instance.RecordTimer.saveTimer()
@@ -738,7 +738,7 @@ class EPGFetcher(object):
 
     def deleteTimer(self, ice_timer_id):
         try:
-            #print "[IceTV] deleting timer:", ice_timer_id
+            # print "[IceTV] deleting timer:", ice_timer_id
             req = ice.Timer(ice_timer_id)
             req.delete()
             self.addLog(_("Timer deleted OK"))
@@ -751,7 +751,7 @@ class EPGFetcher(object):
             req = ice.Timer(timer.ice_timer_id)
             req.data["message"] = message
             req.data["state"] = state
-            #print "[EPGFetcher] postStatus", timer.name, message, state
+            # print "[EPGFetcher] postStatus", timer.name, message, state
             res = req.put()
         except (IOError, RuntimeError, KeyError) as ex:
             _logResponseException(self, _("Can not update timer status"), ex)
@@ -819,7 +819,7 @@ class IceTVMain(ChoiceBox):
                 (_("Enable IceTV"), "CALLFUNC", self.enable),
                 (_("Disable IceTV"), "CALLFUNC", self.disable),
                ]
-        super(IceTVMain, self).__init__(session, title=_("IceTV version %s") % ice._version_string, list=menu, skin_name=self.skinName , titlebartext = _("IceTV - Setup"))
+        super(IceTVMain, self).__init__(session, title=_("IceTV version %s") % ice._version_string, list=menu, skin_name=self.skinName, titlebartext=_("IceTV - Setup"))
         self["debugactions"] = ActionMap(
             contexts=["DirectionActions"],
             actions={
@@ -872,7 +872,7 @@ class IceTVLogView(TextBox):
 
 class IceTVUserTypeScreen(Screen):
     skin = """
-<screen name="IceTVUserTypeScreen" position="320,130" size="640,400" title="" >
+<screen name="IceTVUserTypeScreen" position="320,130" size="640,400" title="IceTV - Account selection" >
  <widget position="20,20" size="600,40" name="title" font="Regular;32" />
  <widget position="20,80" size="600,200" name="instructions" font="Regular;22" />
  <widget position="20,300" size="600,100" name="menu" />
@@ -916,7 +916,7 @@ class IceTVUserTypeScreen(Screen):
 
 class IceTVNewUserSetup(ConfigListScreen, Screen):
     skin = """
-<screen name="IceTVNewUserSetup" position="320,230" size="640,310" title="" >
+<screen name="IceTVNewUserSetup" position="320,230" size="640,310" title="IceTV - User Information" >
     <widget name="instructions" position="20,10" size="600,100" font="Regular;22" />
     <widget name="config" position="20,120" size="600,100" />
 
@@ -1001,7 +1001,7 @@ class IceTVOldUserSetup(IceTVNewUserSetup):
 
 class IceTVRegionSetup(Screen):
     skin = """
-<screen name="IceTVRegionSetup" position="320,130" size="640,510" title="" >
+<screen name="IceTVRegionSetup" position="320,130" size="640,510" title="IceTV - Region" >
     <widget name="instructions" position="20,10" size="600,100" font="Regular;22" />
     <widget name="config" position="30,120" size="580,300" enableWrapAround="1" scrollbarMode="showAlways"/>
     <widget name="error" position="30,120" size="580,300" font="Console; 16" zPosition="1" />
@@ -1063,7 +1063,7 @@ class IceTVRegionSetup(Screen):
         try:
             res = ice.Regions().get().json()
             regions = res["regions"]
-            #print "[icetv] regions:",regions
+            # print "[icetv] regions:",regions
             rl = []
             for region in regions:
                 rl.append((str(region["name"]), int(region["id"]), str(region["country"])))
@@ -1080,7 +1080,7 @@ class IceTVRegionSetup(Screen):
 
 class IceTVLogin(Screen):
     skin = """
-<screen name="IceTVLogin" position="220,115" size="840,570" title="" >
+<screen name="IceTVLogin" position="220,115" size="840,570" title="IceTV - Login" >
     <widget name="instructions" position="20,10" size="800,80" font="Regular;22" />
     <widget name="error" position="30,120" size="780,300" font="Console; 16" zPosition="1" />
     <widget name="qrcode" position="292,90" size="256,256" pixmap="/usr/lib/enigma2/python/Plugins/SystemPlugins/IceTV/de_qr_code.png" zPosition="1" />
@@ -1171,7 +1171,7 @@ class IceTVCreateLogin(IceTVLogin):
 
 class IceTVNeedPassword(ConfigListScreen, Screen):
     skin = """
-<screen name="IceTVNeedPassword" position="320,230" size="640,310" title="" >
+<screen name="IceTVNeedPassword" position="320,230" size="640,310" title="IceTV - Password required" >
     <widget name="instructions" position="20,10" size="600,100" font="Regular;22" />
     <widget name="config" position="20,120" size="600,100" />
 


### PR DESCRIPTION
Remove unnecessary differences between the ATV IceTV plugin and the Beyonwiz plugin.

Translate all IceTV log messages that appear in the IceTV "Show log" screen.

Add German genre lookup tables.

Add IceTV server selection.

Do name lookup fallback when an a lamedb service's triple doesn't match an IceTV triple, but there is a name match.

At device registration time and after service scans, send all triples that aren't in the IceTV channel list to the IceTV server.